### PR TITLE
NEW: Adding method to News Holder to be used for pagination with multipl...

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,43 @@ eventual parent location isn't visible, the article will initially appear in
 the root of the site tree, even though it has been created underneath the
 correct location. Refreshing the tree fixes this problem. 
 
+Pagination will not work when using the SubSections loop when the holder
+contains child holder pages because the Pagination details will be separate for
+each child holder page.
+Use the TotalChildArticles loop instead of SubSections to get around this.
+
+```
+<% if TotalChildArticles %>
+		<div <% if FirstLast %>class="$FirstLast"<% end_if %>>
+			<% include NewsListItem %>
+		</div>
+		<% if TotalChildArticles.MoreThanOnePage %>
+			<div id="NextPrevLinks" class="news-pagination">
+			  <% if TotalChildArticles.NotLastPage %>
+				<div id="NextLink" class="next">
+					<p><a class="next" href="$TotalChildArticles.NextLink" 
+						title="View the next page">See older articles</a></p>
+				</div>
+			  <% end_if %>
+			  <% if TotalChildArticles.NotFirstPage %>
+				<div id="PrevLink" class="previous">
+					<p><a class="prev" href="$TotalChildArticles.PrevLink" 
+						title="View the previous page">See newer articles</a></p>
+				</div>
+			  <% end_if %>
+			  <span>
+				<% if TotalChildArticles.PaginationSummary %><% loop TotalChildArticles.PaginationSummary %>
+				  <% if CurrentBool %>
+					<p class="current">
+						$PageNum
+					</p>
+				  <% else %>
+					<a class="pagination-link" href="$Link" i
+						title="View page number $PageNum">$PageNum</a>
+				  <% end_if %>
+				<% end_loop %><% end_if %>
+			  </span>
+			</div>
+		 <% end_if %>
+<% end_if %>
+```

--- a/code/pages/NewsHolder.php
+++ b/code/pages/NewsHolder.php
@@ -250,6 +250,29 @@ class NewsHolder extends Page {
 		return $urls;
 	}
 
+	/**
+	 * We do not want to use NewsHolder->SubSections because this splits the paginations into
+	 * the categories the articles are in which means the pagination will not work or will display
+	 * multiple times
+	 *
+	 * @return Array
+	 */
+	public function TotalChildArticles($number = null) {
+		if (!$number) {
+			$number = $this->numberToDisplay;
+		}
+
+		$start = isset($_REQUEST['start']) ? (int) $_REQUEST['start'] : 0;
+		if ($start < 0) {
+			$start = 0;
+		}
+
+		$articles = NewsArticle::get('NewsArticle', '', '"OriginalPublishedDate" DESC, "ID" DESC', '', $start . ',' . $number)
+			->filter(array('ID' => $this->getDescendantIDList()));
+		$entries = PaginatedList::create($articles);
+		$entries->setPaginationFromQuery($articles->dataQuery()->query());
+		return $entries;
+	}
 }
 
 class NewsHolder_Controller extends Page_Controller {


### PR DESCRIPTION
Was unable to use a SubSections loop with pagination on a holder page that contained child holder pages which in turn contained child article pages, because the pagination details were being grouped to the child holder pages.

So if I had a Holder page with 2 child holder pages which both contained 9 articles pagination would not work.
Created a new method TotalChildArticles which returns a grouped Datalist so for the example above the Datalist would contain 18 items.
